### PR TITLE
Add cron to replace webhook trigger for testcontainer snapshots

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -28,17 +28,9 @@ pipeline {
         )
     }
     triggers {
-        GenericTrigger(
-            genericVariables: [
-                [key: 'ref', value: '$.ref'],
-            ],
-            tokenCredentialId: 'jenkins-opensearch-testcontainers-generic-webhook-token',
-            causeString: 'A commit was pushed on opensearch-project/testcontainers-opensearch repository main branch causing this workflow to run',
-            printContributedVariables: false,
-            printPostContent: false,
-            regexpFilterText: '$ref',
-            regexpFilterExpression: '^(release)/[0-9]+$'
-        )
+        parameterizedCron '''
+            H 1 * * * %GIT_REFERENCE=main
+        '''
     }
     environment {
         REPO_URL="https://github.com/opensearch-project/testcontainers"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add cron to replace webhook trigger for testcontainer snapshots

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2656

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
