### PR TITLE
Resolve Jenkins file trigger issue due to var substitution

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -41,10 +41,11 @@ pipeline {
         stage('Publish to Sonatype Snapshots Repo') {
             steps {
                 script {
+                    println('Start Trigger')
                     def ref_final = "${GIT_REFERENCE}"
                     def ref_url = "${REPO_URL}/commit/${GIT_REFERENCE}"
                     if (env.USER_BUILD_CAUSE.equals('[]') && env.TIMER_BUILD_CAUSE.equals('[]')) {
-                        ref_final = ${ref}
+                        ref_final = "${ref}"
                         ref_url = "${REPO_URL}/releases/tag/${ref}"
                         println("Triggered by GitHub: ${ref_url}")
 
@@ -53,6 +54,11 @@ pipeline {
                     else {
                         println("Triggered by User/Timer: ${ref_url}")
                         currentBuild.description = """User/Timer: <a href="${ref_url}">${ref_url}</a>"""
+                    }
+
+                    if (ref_final == null || ref_final == '') {
+                        currentBuild.result = 'ABORTED'
+                        error("Missing git reference.")
                     }
 
                     // https://docs.gradle.org/current/samples/sample_publishing_credentials.html


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve Jenkins file trigger issue due to var substitution

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2656

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
