### PR TITLE
Remove webhook trigger part as it is not used in snapshot

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -44,17 +44,9 @@ pipeline {
                     println('Start Trigger')
                     def ref_final = "${GIT_REFERENCE}"
                     def ref_url = "${REPO_URL}/commit/${GIT_REFERENCE}"
-                    if (env.USER_BUILD_CAUSE.equals('[]') && env.TIMER_BUILD_CAUSE.equals('[]')) {
-                        ref_final = "${ref}"
-                        ref_url = "${REPO_URL}/releases/tag/${ref}"
-                        println("Triggered by GitHub: ${ref_url}")
-
-                        currentBuild.description = """GitHub: <a href="${ref_url}">${ref_url}</a>"""
-                    }
-                    else {
-                        println("Triggered by User/Timer: ${ref_url}")
-                        currentBuild.description = """User/Timer: <a href="${ref_url}">${ref_url}</a>"""
-                    }
+                    
+                    println("Triggered by User/Timer: ${ref_url}")
+                    currentBuild.description = """User/Timer: <a href="${ref_url}">${ref_url}</a>"""
 
                     if (ref_final == null || ref_final == '') {
                         currentBuild.result = 'ABORTED'


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove webhook trigger part as it is not used in snapshot

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2656

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
