### PR TITLE
Fix javadoc warning (no @return spec)

### DIFF
--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -70,6 +70,7 @@ public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
     /**
      * Should the security plugin be enabled or stay disabled (default value). If the security
      * plugin is enabled, HTTPS protocol is going to be used along with the default username / password.
+     * @return this container instance
      */
     public OpensearchContainer withSecurityEnabled() {
         this.disableSecurity = false;


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fix javadoc warning (no @return spec)

```
> Task :javadoc

/opensearch-testcontainers/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java:74: warning: no @return
    public OpensearchContainer withSecurityEnabled() {
                               ^
1 warning
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
