### PR TITLE
Remove the test exit 1 command

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         '''
     }
     environment {
-        REPO_URL="https://github.com/opensearch-project/testcontainers"
+        REPO_URL="https://github.com/opensearch-project/opensearch-testcontainers"
         USER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
         TIMER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')
     }

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         )
     }
     environment {
-        REPO_URL="https://github.com/opensearch-project/testcontainers"
+        REPO_URL="https://github.com/opensearch-project/opensearch-testcontainers"
         ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/opensearch-testcontainers"
         USER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
         TIMER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -84,7 +84,6 @@ pipeline {
 
                     // publish maven artifacts
                     sh('./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository')
-                    sh('echo exit1 && exit 1')
                 }
             }
         }


### PR DESCRIPTION
### Description
Remove the test exit 1 command

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2656

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
