### PR TITLE
Disable var printing in jenkins files

### DIFF
--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
             ],
             tokenCredentialId: 'jenkins-opensearch-testcontainers-generic-webhook-token',
             causeString: 'A tag was cut on opensearch-project/opensearch-testcontainers repository causing this workflow to run',
-            printContributedVariables: true,
+            printContributedVariables: false,
             printPostContent: false,
             regexpFilterText: '$ref',
             regexpFilterExpression: '^(release)-[0-9.]+'


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Disable var printing in jenkins files

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2656

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
