### PR TITLE
Allow OpenSearch Docker image to be pulled from Amazon ECR

### DIFF
--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -35,6 +35,10 @@ public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
     // Opensearch Docker base image.
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("opensearchproject/opensearch");
 
+    // Opensearch Docker base image hosted on Amazon ECR
+    private static final DockerImageName ECR_IMAGE_NAME =
+            DockerImageName.parse("public.ecr.aws/opensearchproject/opensearch");
+
     // Disables (or enables) security plugin. If security is enabled, the communication protocol switches from HTTP to
     // HTTPs,
     // along with Basic Auth being used.
@@ -45,7 +49,7 @@ public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
      *
      * @param dockerImageName Full docker image name as a {@link String}, like:
      *     opensearchproject/opensearch:1.2.4 opensearchproject/opensearch:1.3.1
-     *     opensearchproject/opensearch:2.0.0
+     *     opensearchproject/opensearch:2.0.0 or public.ecr.aws/opensearchproject/opensearch:2.4.1
      */
     public OpensearchContainer(String dockerImageName) {
         this(DockerImageName.parse(dockerImageName));
@@ -64,7 +68,7 @@ public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
      */
     public OpensearchContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, ECR_IMAGE_NAME);
     }
 
     /**

--- a/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
+++ b/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -25,6 +26,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -75,6 +77,13 @@ class OpensearchContainerTest {
                         () -> client.performRequest(new Request("GET", "/_plugins/_security/health")));
             }
         }
+    }
+
+    @Test
+    void ecrImageIsCompatibleWithDefaultDockerHubImage() {
+        assertDoesNotThrow(() -> {
+            new OpensearchContainer("public.ecr.aws/opensearchproject/opensearch");
+        });
     }
 
     private static Stream<Arguments> containers() {


### PR DESCRIPTION
### Description
Official OpenSearch Docker images are available off Docker Hub and Amazon ECR (cf. https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/docker/#run-opensearch-in-a-docker-container). This PR adds built-in support for using the ECR-based images.

### Issues Resolved
n/a

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
