### PR TITLE
Facilitate inheriting from OpensearchContainer without breaking with*…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Follow the [JUnit 4 Quickstart](https://www.testcontainers.org/quickstart/junit_
 
 ```java
 @Rule
-public OpensearchContainer opensearch = new OpensearchContainer(DockerImageName.parse("opensearchproject/opensearch:2.0.0"));
+public OpensearchContainer<?> opensearch = new OpensearchContainer<>(DockerImageName.parse("opensearchproject/opensearch:2.0.0"));
 
 ```
 
@@ -45,7 +45,7 @@ Follow the [JUnit 5 Quickstart](https://www.testcontainers.org/quickstart/junit_
 
 ```java
 @Container
-public OpensearchContainer opensearch = new OpensearchContainer(DockerImageName.parse("opensearchproject/opensearch:2.0.0"));
+public OpensearchContainer<?> opensearch = new OpensearchContainer<>(DockerImageName.parse("opensearchproject/opensearch:2.0.0"));
 
 ```
 
@@ -72,7 +72,7 @@ import org.opensearch.client.RestClient;
 private static final DockerImageName OPENSEARCH_IMAGE = DockerImageName.parse("opensearchproject/opensearch:2.0.0");
 
 // Create the Opensearch container.
-try (OpensearchContainer container = new OpensearchContainer(OPENSEARCH_IMAGE).withSecurityEnabled()) {
+try (OpensearchContainer<?> container = new OpensearchContainer<>(OPENSEARCH_IMAGE).withSecurityEnabled()) {
     // Start the container. This step might take some time...
     container.start();
 
@@ -115,7 +115,7 @@ import org.opensearch.client.RestClient;
 private static final DockerImageName OPENSEARCH_IMAGE = DockerImageName.parse("opensearchproject/opensearch:2.0.0");
 
 // Create the OpenSearch container.
-try (OpensearchContainer container = new OpensearchContainer(OPENSEARCH_IMAGE)) {
+try (OpensearchContainer<?> container = new OpensearchContainer<>(OPENSEARCH_IMAGE)) {
     // Start the container. This step might take some time...
     container.start();
 

--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -20,7 +20,7 @@ import org.testcontainers.utility.DockerImageName;
  * The Opensearch Docker container (single node cluster) which exposes by default ports 9200
  * (http/https) and 9300 (tcp, deprecated).
  */
-public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
+public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends GenericContainer<SELF> {
     // Default username to connect to Opensearch instance
     private static final String DEFAULT_USER = "admin";
     // Default password to connect to Opensearch instance
@@ -72,9 +72,9 @@ public class OpensearchContainer extends GenericContainer<OpensearchContainer> {
      * plugin is enabled, HTTPS protocol is going to be used along with the default username / password.
      * @return this container instance
      */
-    public OpensearchContainer withSecurityEnabled() {
+    public SELF withSecurityEnabled() {
         this.disableSecurity = false;
-        return this;
+        return self();
     }
 
     @Override

--- a/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
+++ b/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
@@ -39,7 +39,7 @@ class OpensearchContainerTest {
     @ParameterizedTest(name = "Running Opensearch version={0} (security enabled)")
     @MethodSource("containers")
     public void defaultWithSecurity(final String version, final DockerImageName image) throws Exception {
-        try (OpensearchContainer container = new OpensearchContainer(image).withSecurityEnabled()) {
+        try (OpensearchContainer<?> container = new OpensearchContainer<>(image).withSecurityEnabled()) {
             container.start();
 
             try (RestClient client = getClient(container)) {
@@ -60,7 +60,7 @@ class OpensearchContainerTest {
     @ParameterizedTest(name = "Running Opensearch version={0} (security disabled)")
     @MethodSource("containers")
     public void defaultNoSecurity(final String version, final DockerImageName image) throws Exception {
-        try (OpensearchContainer container = new OpensearchContainer(image)) {
+        try (OpensearchContainer<?> container = new OpensearchContainer<>(image)) {
             container.start();
 
             try (RestClient client = getClient(container)) {
@@ -90,7 +90,7 @@ class OpensearchContainerTest {
                         DockerImageName.parse("opensearchproject/opensearch").withTag("2.1.0")));
     }
 
-    private RestClient getClient(OpensearchContainer container)
+    private RestClient getClient(OpensearchContainer<?> container)
             throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
         final CredentialsProvider credentialsProvider =
                 getCredentialsProvider(container).orElse(null);
@@ -108,7 +108,7 @@ class OpensearchContainerTest {
                 .build();
     }
 
-    private Optional<CredentialsProvider> getCredentialsProvider(OpensearchContainer container) {
+    private Optional<CredentialsProvider> getCredentialsProvider(OpensearchContainer<?> container) {
         if (!container.isSecurityEnabled()) {
             return Optional.empty();
         }


### PR DESCRIPTION
… methods (fixes #51)

Signed-off-by: Thilo-Alexander Ginkel <tg@tgbyte.de>

### Description
This PR extends `OpensearchContainer` according to the standard Testcontainers mechanism (using Java generics) to facilitate extending `OpensearchContainer` without breaking `with*` methods (due to an incorrect return type).

### Issues Resolved
#51

### Check List
- [ ] New functionality includes testing. N/A
  - [X] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added N/A
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
