### PR TITLE
Fix Maven local repository location (post Gradle 8.4 update)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,7 +125,7 @@ publishing {
         }
       }
     }
-    maven("${rootProject.layout.buildDirectory}/repository") {
+    maven(rootProject.layout.buildDirectory.dir("repository")) {
       name = "localRepo"
     }
   }


### PR DESCRIPTION
### Description
Fix Maven local repository location (post Gradle 8.4 update)

### Issues Resolved
It seems like Gradle changed `buildDirectory` from `dir` to `property` so it resolved to 

```
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /home/user/opensearch-testcontainers/build))/repository
```

Failing the release drafter:

```
 tar: build: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
