### PR TITLE
Fix ReleaseExtension which requires versionPropertyFile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,7 @@ spotless {
 configure<ReleaseExtension> {
   with(git) {
     requireBranch.set("main")
+    versionPropertyFile.set("version.properties")
   }
 }
 


### PR DESCRIPTION
### Description
Fix ReleaseExtension which requires versionPropertyFile

### Issues Resolved
```

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':opensearch-testcontainers-release:unSnapshotVersion'.
> [/home/runner/work/opensearch-testcontainers/opensearch-testcontainers/gradle.properties] contains no 'version' property. Expression: properties.version

```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
