### PR TITLE
Add support for OPENSEARCH_INITIAL_ADMIN_PASSWORD that is required by OpenSearch 2.12.0 or later

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 11, 17, 21 ]
+        java-version: [ 11, 17, 21, 23 ]
         runs-on: [ubuntu-latest]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.11.0")
   testImplementation("ch.qos.logback:logback-classic:1.5.8")
-  testImplementation("org.opensearch.client:opensearch-rest-client:2.16.0")
+  testImplementation("org.opensearch.client:opensearch-rest-client:2.17.0")
 }
 
 group = "org.opensearch"

--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -23,8 +23,8 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends GenericContainer<SELF> {
     // The initial password is required starting from OpenSearch 2.12.0
-    private static final Pattern OPENSEARCH_INITIAL_PASSWORD_VERSION =
-            Pattern.compile("^(([3][.]\\d+[.]\\d+|[2][.][1][2-9]+[.]\\d+|[2][.][2-9]\\d+[.]\\d+)(-SNAPSHOT)?|latest)$");
+    private static final Pattern OPENSEARCH_INITIAL_PASSWORD_VERSION = Pattern.compile(
+            "^(([3-9][.]\\d+[.]\\d+|[2][.][1][2-9]+[.]\\d+|[2][.][2-9]\\d+[.]\\d+)(-SNAPSHOT)?|latest)$");
 
     // Default username to connect to Opensearch instance
     private static final String DEFAULT_USER = "admin";

--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -24,7 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends GenericContainer<SELF> {
     // The initial password is required starting from OpenSearch 2.12.0
     private static final Pattern OPENSEARCH_INITIAL_PASSWORD_VERSION =
-            Pattern.compile("^([3][.]\\d+[.]\\d+|[2][.][1][2-9]+[.]\\d+|[2][.][2-9]\\d+[.]\\d+|latest)$");
+            Pattern.compile("^(([3][.]\\d+[.]\\d+|[2][.][1][2-9]+[.]\\d+|[2][.][2-9]\\d+[.]\\d+)(-SNAPSHOT)?|latest)$");
 
     // Default username to connect to Opensearch instance
     private static final String DEFAULT_USER = "admin";

--- a/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpensearchContainer.java
@@ -10,6 +10,7 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.regex.Pattern;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -21,10 +22,16 @@ import org.testcontainers.utility.DockerImageName;
  * (http/https) and 9300 (tcp, deprecated).
  */
 public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends GenericContainer<SELF> {
+    // The initial password is required starting from OpenSearch 2.12.0
+    private static final Pattern OPENSEARCH_INITIAL_PASSWORD_VERSION =
+            Pattern.compile("^([3][.]\\d+[.]\\d+|[2][.][1][2-9]+[.]\\d+|[2][.][2-9]\\d+[.]\\d+|latest)$");
+
     // Default username to connect to Opensearch instance
     private static final String DEFAULT_USER = "admin";
     // Default password to connect to Opensearch instance
     private static final String DEFAULT_PASSWORD = "admin";
+    // Default initial password to connect to Opensearch instance
+    private static final String DEFAULT_INITIAL_PASSWORD = "_ad0m#Ns_";
 
     // Default HTTP port.
     private static final int DEFAULT_HTTP_PORT = 9200;
@@ -39,6 +46,8 @@ public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends
     // HTTPs,
     // along with Basic Auth being used.
     private boolean disableSecurity = true;
+    private boolean requireInitialPassword = false;
+    private String password = DEFAULT_PASSWORD;
 
     /**
      * Create an Opensearch Container by passing the full docker image name.
@@ -65,6 +74,14 @@ public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends
     public OpensearchContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        final String version = dockerImageName.getVersionPart();
+        if (version == null || version.isBlank()) {
+            requireInitialPassword = false; /* we don't know the version */
+        } else {
+            requireInitialPassword =
+                    OPENSEARCH_INITIAL_PASSWORD_VERSION.matcher(version).matches();
+        }
     }
 
     /**
@@ -85,6 +102,13 @@ public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends
         withEnv("discovery.type", "single-node");
         if (disableSecurity) {
             withEnv("DISABLE_SECURITY_PLUGIN", Boolean.toString(disableSecurity));
+        } else if (requireInitialPassword) {
+            // Check if the OPENSEARCH_INITIAL_ADMIN_PASSWORD is already provided
+            password = getEnvMap().get("OPENSEARCH_INITIAL_ADMIN_PASSWORD");
+            if (password == null || password.isBlank()) {
+                withEnv("OPENSEARCH_INITIAL_ADMIN_PASSWORD", DEFAULT_INITIAL_PASSWORD);
+                password = DEFAULT_INITIAL_PASSWORD;
+            }
         }
         addExposedPorts(DEFAULT_HTTP_PORT, DEFAULT_TCP_PORT);
 
@@ -96,7 +120,7 @@ public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends
                     .usingTls()
                     .allowInsecure()
                     .forPort(DEFAULT_HTTP_PORT)
-                    .withBasicCredentials(DEFAULT_USER, DEFAULT_PASSWORD)
+                    .withBasicCredentials(DEFAULT_USER, password)
                     .forStatusCodeMatching(response -> response == HTTP_OK || response == HTTP_UNAUTHORIZED)
                     .withReadTimeout(Duration.ofSeconds(10))
                     .withStartupTimeout(Duration.ofMinutes(5));
@@ -153,6 +177,6 @@ public class OpensearchContainer<SELF extends OpensearchContainer<SELF>> extends
      * @return password to connect to Opensearch container
      */
     public String getPassword() {
-        return DEFAULT_PASSWORD;
+        return password;
     }
 }

--- a/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
+++ b/src/test/java/org/opensearch/testcontainers/OpensearchContainerTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertThrows;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
@@ -38,8 +39,10 @@ class OpensearchContainerTest {
     @DisplayName("Create default OpensearchContainer with security enabled")
     @ParameterizedTest(name = "Running Opensearch version={0} (security enabled)")
     @MethodSource("containers")
-    public void defaultWithSecurity(final String version, final DockerImageName image) throws Exception {
-        try (OpensearchContainer<?> container = new OpensearchContainer<>(image).withSecurityEnabled()) {
+    public void defaultWithSecurity(final String version, final Map<String, String> env, final DockerImageName image)
+            throws Exception {
+        try (OpensearchContainer<?> container =
+                new OpensearchContainer<>(image).withEnv(env).withSecurityEnabled()) {
             container.start();
 
             try (RestClient client = getClient(container)) {
@@ -59,8 +62,9 @@ class OpensearchContainerTest {
     @DisplayName("Create OpensearchContainer with security disabled")
     @ParameterizedTest(name = "Running Opensearch version={0} (security disabled)")
     @MethodSource("containers")
-    public void defaultNoSecurity(final String version, final DockerImageName image) throws Exception {
-        try (OpensearchContainer<?> container = new OpensearchContainer<>(image)) {
+    public void defaultNoSecurity(final String version, final Map<String, String> env, final DockerImageName image)
+            throws Exception {
+        try (OpensearchContainer<?> container = new OpensearchContainer<>(image).withEnv(env)) {
             container.start();
 
             try (RestClient client = getClient(container)) {
@@ -81,16 +85,28 @@ class OpensearchContainerTest {
         return Stream.of(
                 Arguments.of(
                         "1.3.4",
+                        Map.of(), /* empty env */
                         DockerImageName.parse("opensearchproject/opensearch").withTag("1.3.4")),
                 Arguments.of(
                         "2.0.1",
+                        Map.of(), /* empty env */
                         DockerImageName.parse("opensearchproject/opensearch").withTag("2.0.1")),
                 Arguments.of(
                         "2.1.0",
+                        Map.of(), /* empty env */
                         DockerImageName.parse("opensearchproject/opensearch").withTag("2.1.0")),
                 Arguments.of(
                         "2.11.0",
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.11.0")));
+                        Map.of(), /* empty env */
+                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.11.0")),
+                Arguments.of(
+                        "2.15.0",
+                        Map.of("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "_oop0m#NsR_"),
+                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.15.0")),
+                Arguments.of(
+                        "2.17.0",
+                        Map.of(), /* empty env */
+                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.17.0")));
     }
 
     private RestClient getClient(OpensearchContainer<?> container)


### PR DESCRIPTION
### Description
Add support for OPENSEARCH_INITIAL_ADMIN_PASSWORD that is required by OpenSearch 2.12.0 or later

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
