### PR TITLE
Stepping @dblock down to Emeritus.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                           | Affiliation |
-| ------------------------ | --------------------------------------------------- | ----------- |
-| Andriy Redko             | [reta](https://github.com/reta)                     | Aiven       |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                 | Amazon      |
-| Peter Zhu                | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
+| Maintainer   | GitHub ID                                           | Affiliation |
+| ------------ | --------------------------------------------------- | ----------- |
+| Andriy Redko | [reta](https://github.com/reta)                     | Independent |
+| Peter Zhu    | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
+
+## Emeritus
+
+| Maintainer               | GitHub ID                           | Affiliation |
+| ------------------------ | ----------------------------------- | ----------- |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Independent |


### PR DESCRIPTION
### Description

I've mostly been merging code in this repo blindly to help @reta out. Now that I don't work on OpenSearch full time I'd like to step down from the maintainers here, please remove my maintainer permissions. Also fixed @reta's affiliation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
