### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -23,11 +23,15 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Publish snapshots to maven
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,4 +41,4 @@ The release process is standard across repositories in this org and is run by a 
 1. Increment "version" in [version.properties](./version.properties) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-testcontainers/pull/39).
 
 ## Snapshot Builds
-The [snapshots builds](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/opensearch-testcontainers/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch (or other active release branch like `1.x`) triggers this workflow.
+The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/opensearch-testcontainers/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch (or other active release branch like `1.x`) triggers this workflow.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,13 +40,16 @@ repositories {
     url = uri("https://repo.maven.apache.org/maven2/")
   }
   maven {
+    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+  }
+  maven {
     url = uri("https://aws.oss.sonatype.org/content/repositories/snapshots/")
   }
 }
 
 dependencies {
   implementation("org.testcontainers:testcontainers:1.21.1")
-  testImplementation(platform("org.junit:junit-bom:5.13.1")) 
+  testImplementation(platform("org.junit:junit-bom:5.13.1"))
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("ch.qos.logback:logback-classic:1.5.18")
@@ -67,14 +70,14 @@ if (isSnapshot && !buildVersion.endsWith("SNAPSHOT")) {
 } else if (!isSnapshot && buildVersion.endsWith("SNAPSHOT")) {
   throw GradleException("Expecting release (non-SNAPSHOT) build but version is not set accordingly: " + buildVersion)
 }
-  
-// Check if tag release version (if provided) matches the version from build settings 
+
+// Check if tag release version (if provided) matches the version from build settings
 val tagVersion = System.getProperty("build.version", buildVersion)
 if (!buildVersion.equals(tagVersion)) {
   throw GradleException("The tagged version " + tagVersion + " does not match the build version " + buildVersion)
 }
 
-version = buildVersion 
+version = buildVersion
 description = "Testcontainers for Opensearch"
 
 java {
@@ -125,7 +128,7 @@ configure<ReleaseExtension> {
 publishing {
   repositories{
     if (version.toString().endsWith("SNAPSHOT")) {
-      maven("https://aws.oss.sonatype.org/content/repositories/snapshots/") {
+      maven("https://central.sonatype.com/repository/maven-snapshots/") {
         name = "snapshotRepo"
         credentials {
             username = System.getenv("SONATYPE_USERNAME")


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this `OpenSearch` repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign from https://github.com/opensearch-project/opensearch-build/issues/5551

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
