### PR TITLE
Provide the way to reference image just by version number

### DIFF
--- a/src/main/java/org/opensearch/testcontainers/OpenSearchContainer.java
+++ b/src/main/java/org/opensearch/testcontainers/OpenSearchContainer.java
@@ -62,7 +62,10 @@ public class OpenSearchContainer<SELF extends OpenSearchContainer<SELF>> extends
 
     /**
      * Create an OpenSearch Container (with security plugin enabled) by passing the full docker image
-     * name.
+     * name. {@link OpenSearchDockerImage} helper class could be used to refer to the official images
+     * by version tag only:
+     *
+     *      OpenSearchDockerImage.ofVersion("1.2.4")
      *
      * @param dockerImageName Full docker image name as a {@link DockerImageName}, like:
      *

--- a/src/main/java/org/opensearch/testcontainers/OpenSearchDockerImage.java
+++ b/src/main/java/org/opensearch/testcontainers/OpenSearchDockerImage.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.testcontainers;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Official Docker images of the OpenSearch project: https://hub.docker.com/r/opensearchproject/opensearch
+ */
+public final class OpenSearchDockerImage {
+    public static DockerImageName ofVersion(String version) {
+        return ofTag(version);
+    }
+
+    public static DockerImageName ofTag(String tag) {
+        return DockerImageName.parse("opensearchproject/opensearch:" + tag);
+    }
+}

--- a/src/test/java/org/opensearch/testcontainers/OpenSearchContainerClusterTest.java
+++ b/src/test/java/org/opensearch/testcontainers/OpenSearchContainerClusterTest.java
@@ -141,7 +141,7 @@ class OpenSearchContainerClusterTest {
                         "master",
                         "node.name",
                         "master"),
-                DockerImageName.parse("opensearchproject/opensearch").withTag("3.1.0")));
+                OpenSearchDockerImage.ofVersion("3.1.0")));
     }
 
     private RestClient getClient(OpenSearchContainer<?> container)

--- a/src/test/java/org/opensearch/testcontainers/OpenSearchContainerTest.java
+++ b/src/test/java/org/opensearch/testcontainers/OpenSearchContainerTest.java
@@ -102,47 +102,47 @@ class OpenSearchContainerTest {
                         "1.3.4",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("1.3.4")),
+                        OpenSearchDockerImage.ofVersion("1.3.4")),
                 Arguments.of(
                         "2.0.1",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.0.1")),
+                        OpenSearchDockerImage.ofVersion("2.0.1")),
                 Arguments.of(
                         "2.1.0",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.1.0")),
+                        OpenSearchDockerImage.ofVersion("2.1.0")),
                 Arguments.of(
                         "2.11.0",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.11.0")),
+                        OpenSearchDockerImage.ofVersion("2.11.0")),
                 Arguments.of(
                         "2.15.0",
                         Map.of("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "_oop0m#NsR_"),
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.15.0")),
+                        OpenSearchDockerImage.ofVersion("2.15.0")),
                 Arguments.of(
                         "2.17.0",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.17.0")),
+                        OpenSearchDockerImage.ofVersion("2.17.0")),
                 Arguments.of(
                         "2.19.1",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.1")),
+                        OpenSearchDockerImage.ofVersion("2.19.1")),
                 Arguments.of(
                         "3.1.0",
                         Map.of(), /* empty env */
                         TlsConfig.custom(),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("3.1.0")),
+                        OpenSearchDockerImage.ofVersion("3.1.0")),
                 Arguments.of(
-                        "3.1.0",
+                        "3.2.0",
                         Map.of(), /* empty env */
                         TlsConfig.custom().setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2),
-                        DockerImageName.parse("opensearchproject/opensearch").withTag("3.1.0")));
+                        OpenSearchDockerImage.ofVersion("3.2.0")));
     }
 
     private RestClient getClient(OpenSearchContainer<?> container, final TlsConfig.Builder tlsConfig)


### PR DESCRIPTION
### Description
Provide the way to reference image just by version number: 

```java
new OpenSearchContainer(OpenSearchDockerImage.ofVersion("3.2.0"))
```


### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-testcontainers/issues/288

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
