### PR TITLE
Onboarding new maven snapshots publishing to s3 (testcontainers)

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
       branches:
-        - main
-        - 1.x
+        - 'main'
+        - '[0-9]+.x'
 
 jobs:
   build-and-publish-snapshots:
@@ -30,8 +30,14 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
-          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+          MAVEN_SNAPSHOTS_S3_REPO: op://opensearch-infra-secrets/maven-snapshots-s3/repo
+          MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
+          aws-region: us-east-1
 
       - name: Publish snapshots to maven
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,4 +41,4 @@ The release process is standard across repositories in this org and is run by a 
 1. Increment "version" in [version.properties](./version.properties) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-testcontainers/pull/39).
 
 ## Snapshot Builds
-The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/opensearch-testcontainers/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch (or other active release branch like `1.x`) triggers this workflow.
+The [snapshots builds](https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/opensearch-testcontainers/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch (or other active release branch like `1.x`) triggers this workflow.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,7 @@ repositories {
     url = uri("https://repo.maven.apache.org/maven2/")
   }
   maven {
-    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-  }
-  maven {
-    url = uri("https://aws.oss.sonatype.org/content/repositories/snapshots/")
+    url = uri("https://ci.opensearch.org/ci/dbc/snapshots/maven/")
   }
 }
 
@@ -129,11 +126,11 @@ configure<ReleaseExtension> {
 publishing {
   repositories{
     if (version.toString().endsWith("SNAPSHOT")) {
-      maven("https://central.sonatype.com/repository/maven-snapshots/") {
-        name = "snapshotRepo"
-        credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_PASSWORD")
+      maven(providers.environmentVariable("MAVEN_SNAPSHOTS_S3_REPO")) {
+        credentials(AwsCredentials::class) {
+          accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+          secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+          sessionToken = System.getenv("AWS_SESSION_TOKEN")
         }
       }
     }


### PR DESCRIPTION
### Description
Onboarding new maven snapshots publishing to s3 (testcontainers)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5360

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
